### PR TITLE
test:Add test for GetSalesDailyDateProducts

### DIFF
--- a/app/Http/Controllers/GetSalesDailyDateProductsController.php
+++ b/app/Http/Controllers/GetSalesDailyDateProductsController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Sales;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class GetSalesDailyDateProductsController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param Request $request
+     * @param String $date
+     * @return JsonResponse
+     */
+    public function __invoke(Request $request, string $date): JsonResponse
+    {
+        return response()->json([
+            'details' => Sales::fetchDailySalesProducts($date),
+        ], 200, [], JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/app/Models/Sales.php
+++ b/app/Models/Sales.php
@@ -97,7 +97,6 @@ class Sales extends Model
             ->select('products.name as product')
             ->selectRaw('sum(products.price * quantity) as amount')
             ->where('date', $date)
-            ->join('stores', 'stores.id', '=', 'sales.store_id')
             ->join('products', 'products.id', '=', 'sales.product_id')
             ->groupBy('product')
             ->withCasts([

--- a/app/Models/Sales.php
+++ b/app/Models/Sales.php
@@ -84,4 +84,24 @@ class Sales extends Model
                 'total' => 'integer',
             ])->get();
     }
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @param $date
+     * @return Collection
+     */
+    public static function fetchDailySalesProducts($date): Collection
+    {
+        return self::query()
+            ->select('products.name as product')
+            ->selectRaw('sum(products.price * quantity) as total')
+            ->where('date', $date)
+            ->join('stores', 'stores.id', '=', 'sales.store_id')
+            ->join('products', 'products.id', '=', 'sales.product_id')
+            ->groupBy('product')
+            ->withCasts([
+                'total' => 'integer',
+            ])->get();
+    }
 }

--- a/app/Models/Sales.php
+++ b/app/Models/Sales.php
@@ -75,13 +75,13 @@ class Sales extends Model
     {
         return self::query()
             ->select('stores.name as store')
-            ->selectRaw('sum(products.price * quantity) as total')
+            ->selectRaw('sum(products.price * quantity) as amount')
             ->where('date', $date)
             ->join('stores', 'stores.id', '=', 'sales.store_id')
             ->join('products', 'products.id', '=', 'sales.product_id')
             ->groupBy('store')
             ->withCasts([
-                'total' => 'integer',
+                'amount' => 'integer',
             ])->get();
     }
 
@@ -95,13 +95,13 @@ class Sales extends Model
     {
         return self::query()
             ->select('products.name as product')
-            ->selectRaw('sum(products.price * quantity) as total')
+            ->selectRaw('sum(products.price * quantity) as amount')
             ->where('date', $date)
             ->join('stores', 'stores.id', '=', 'sales.store_id')
             ->join('products', 'products.id', '=', 'sales.product_id')
             ->groupBy('product')
             ->withCasts([
-                'total' => 'integer',
+                'amount' => 'integer',
             ])->get();
     }
 }

--- a/database/seeders/GetSalesDailyDateProductsTestSeeder.php
+++ b/database/seeders/GetSalesDailyDateProductsTestSeeder.php
@@ -22,18 +22,11 @@ class GetSalesDailyDateProductsTestSeeder extends Seeder
         foreach (Store::orderBy('id', 'asc')->pluck('id') as $idx => $store_id ) {
             foreach (Product::pluck('id') as $product_id) {
                 Sales::create([
-                    'date' => date('Y-m-d'),
+                    'date' => '2023-01-02',
                     'user_id' => $user_id,
                     'store_id' => $store_id,
                     'product_id' => $product_id,
                     'quantity' => $idx+1,
-                ]);
-                Sales::create([
-                    'date' => date('Y-m-d', strtotime('-2 day')),
-                    'user_id' => $user_id,
-                    'store_id' => $store_id,
-                    'product_id' => $product_id,
-                    'quantity' => ($idx+1)*3,
                 ]);
             }
         }

--- a/database/seeders/GetSalesDailyDateProductsTestSeeder.php
+++ b/database/seeders/GetSalesDailyDateProductsTestSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Product;
+use App\Models\Sales;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class GetSalesDailyDateProductsTestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $user_id = User::orderBy('id', 'asc')->first()->value('id');
+        foreach (Store::orderBy('id', 'asc')->pluck('id') as $idx => $store_id ) {
+            foreach (Product::pluck('id') as $product_id) {
+                Sales::create([
+                    'date' => date('Y-m-d'),
+                    'user_id' => $user_id,
+                    'store_id' => $store_id,
+                    'product_id' => $product_id,
+                    'quantity' => $idx+1,
+                ]);
+                Sales::create([
+                    'date' => date('Y-m-d', strtotime('-2 day')),
+                    'user_id' => $user_id,
+                    'store_id' => $store_id,
+                    'product_id' => $product_id,
+                    'quantity' => ($idx+1)*3,
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/GetSalesDailyDateStoresTestSeeder.php
+++ b/database/seeders/GetSalesDailyDateStoresTestSeeder.php
@@ -23,18 +23,11 @@ class GetSalesDailyDateStoresTestSeeder extends Seeder
         foreach (Store::orderBy('id', 'asc')->pluck('id') as $idx => $store_id ) {
             foreach (Product::pluck('id') as $product_id) {
                 Sales::create([
-                    'date' => date('Y-m-d'),
+                    'date' => '2023-01-01',
                     'user_id' => $user_id,
                     'store_id' => $store_id,
                     'product_id' => $product_id,
                     'quantity' => $idx+1,
-                ]);
-                Sales::create([
-                    'date' => date('Y-m-d', strtotime('-1 day')),
-                    'user_id' => $user_id,
-                    'store_id' => $store_id,
-                    'product_id' => $product_id,
-                    'quantity' => ($idx+1)*2,
                 ]);
             }
         }

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\GetSalesDailyController;
 use App\Http\Controllers\GetSalesDailyDateController;
+use App\Http\Controllers\GetSalesDailyDateProductsController;
 use App\Http\Controllers\GetSalesDailyDateStoresController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -29,3 +30,4 @@ Route::pattern('date', '^([1-9][0-9]{3})-([1-9]{1}|0[1-9]{1}|1[0-2]{1})-([1-9]{1
 Route::get('/sales/daily', GetSalesDailyController::class);
 Route::get('/sales/daily/{date}', GetSalesDailyDateController::class);
 Route::get('/sales/daily/{date}/stores', GetSalesDailyDateStoresController::class);
+Route::get('/sales/daily/{date}/products', GetSalesDailyDateProductsController::class);

--- a/tests/Feature/GetSalesDailyDateProductsTest.php
+++ b/tests/Feature/GetSalesDailyDateProductsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\GetSalesDailyDateProductsTestSeeder;
+use Database\Seeders\ProductSeeder;
+use Database\Seeders\StoreSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetSalesDailyDateProductsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(UserSeeder::class);
+        $this->seed(StoreSeeder::class);
+        $this->seed(ProductSeeder::class);
+        $this->seed(GetSalesDailyDateProductsTestSeeder::class);
+    }
+
+    /**
+     * Return 404 if an invalid value is entered.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_404_if_input_an_invalid_value(): void
+    {
+        $response = $this->get('/api/sales/daily/abc/products');
+        $response->assertStatus(404);
+    }
+
+    /**
+     * Test if you are returns a certain type.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_certain_type(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) =>
+        $json->whereAllType([
+            'details.0.product' => 'string',
+            'details.0.total' => 'integer',
+        ]));
+    }
+
+    /**
+     * Test if you are returns a correct product name.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_correct_product_name(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response->assertStatus(200);
+        $products = ['もち','おはぎ','おこわ','みそ'];
+        foreach ($products as $i => $value) {
+            $response->assertJson(fn(AssertableJson $json) => $json->where('details.' . strval($i) . '.product', $value));
+        }
+    }
+
+    /**
+     * Test if you are returns a correct product sales on the day.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_correct_product_sales_on_the_day(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) =>
+        $json->where('details.0.total', 7500)
+            ->where('details.1.total', 2500)
+            ->where('details.2.total', 3000)
+            ->where('details.3.total', 5000));
+    }
+
+    /**
+     * Test if you are returns a correct product sales 2 days ago.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_correct_product_sales_2_days_ago(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d', strtotime('-2 day')) . '/products');
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) =>
+        $json->where('details.0.total', 7500*3)
+            ->where('details.1.total', 2500*3)
+            ->where('details.2.total', 3000*3)
+            ->where('details.3.total', 5000*3));
+    }
+}

--- a/tests/Feature/GetSalesDailyDateProductsTest.php
+++ b/tests/Feature/GetSalesDailyDateProductsTest.php
@@ -43,7 +43,7 @@ class GetSalesDailyDateProductsTest extends TestCase
     public function test_the_application_returns_a_certain_type(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response = $this->getJson('/api/sales/daily/2023-01-02/products');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
@@ -60,7 +60,7 @@ class GetSalesDailyDateProductsTest extends TestCase
     public function test_the_application_returns_a_correct_product_name(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response = $this->getJson('/api/sales/daily/2023-01-02/products');
         $response->assertStatus(200);
         $products = ['もち','おはぎ','おこわ','みそ'];
         foreach ($products as $i => $value) {
@@ -69,36 +69,19 @@ class GetSalesDailyDateProductsTest extends TestCase
     }
 
     /**
-     * Test if you are returns a correct product sales on the day.
+     * Test if you are returns a correct product sales.
      *
      * @return void
      */
-    public function test_the_application_returns_a_correct_product_sales_on_the_day(): void
+    public function test_the_application_returns_a_correct_product_sales(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
+        $response = $this->getJson('/api/sales/daily/2023-01-02/products');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
         $json->where('details.0.amount', 7500)
             ->where('details.1.amount', 2500)
             ->where('details.2.amount', 3000)
             ->where('details.3.amount', 5000));
-    }
-
-    /**
-     * Test if you are returns a correct product sales 2 days ago.
-     *
-     * @return void
-     */
-    public function test_the_application_returns_a_correct_product_sales_2_days_ago(): void
-    {
-        $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d', strtotime('-2 day')) . '/products');
-        $response->assertStatus(200);
-        $response->assertJson(fn (AssertableJson $json) =>
-        $json->where('details.0.amount', 7500*3)
-            ->where('details.1.amount', 2500*3)
-            ->where('details.2.amount', 3000*3)
-            ->where('details.3.amount', 5000*3));
     }
 }

--- a/tests/Feature/GetSalesDailyDateProductsTest.php
+++ b/tests/Feature/GetSalesDailyDateProductsTest.php
@@ -48,7 +48,7 @@ class GetSalesDailyDateProductsTest extends TestCase
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
             'details.0.product' => 'string',
-            'details.0.total' => 'integer',
+            'details.0.amount' => 'integer',
         ]));
     }
 
@@ -79,10 +79,10 @@ class GetSalesDailyDateProductsTest extends TestCase
         $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/products');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
-        $json->where('details.0.total', 7500)
-            ->where('details.1.total', 2500)
-            ->where('details.2.total', 3000)
-            ->where('details.3.total', 5000));
+        $json->where('details.0.amount', 7500)
+            ->where('details.1.amount', 2500)
+            ->where('details.2.amount', 3000)
+            ->where('details.3.amount', 5000));
     }
 
     /**
@@ -96,9 +96,9 @@ class GetSalesDailyDateProductsTest extends TestCase
         $response = $this->getJson('/api/sales/daily/' . date('Y-m-d', strtotime('-2 day')) . '/products');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
-        $json->where('details.0.total', 7500*3)
-            ->where('details.1.total', 2500*3)
-            ->where('details.2.total', 3000*3)
-            ->where('details.3.total', 5000*3));
+        $json->where('details.0.amount', 7500*3)
+            ->where('details.1.amount', 2500*3)
+            ->where('details.2.amount', 3000*3)
+            ->where('details.3.amount', 5000*3));
     }
 }

--- a/tests/Feature/GetSalesDailyDateStoresTest.php
+++ b/tests/Feature/GetSalesDailyDateStoresTest.php
@@ -48,7 +48,7 @@ class GetSalesDailyDateStoresTest extends TestCase
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
             'details.0.store' => 'string',
-            'details.0.total' => 'integer',
+            'details.0.amount' => 'integer',
         ]));
     }
 
@@ -80,10 +80,10 @@ class GetSalesDailyDateStoresTest extends TestCase
         $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/stores');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
-            $json->where('details.0.total', 1800)
-                ->where('details.1.total', 3600)
-                ->where('details.2.total', 5400)
-                ->where('details.3.total', 7200));
+            $json->where('details.0.amount', 1800)
+                ->where('details.1.amount', 3600)
+                ->where('details.2.amount', 5400)
+                ->where('details.3.amount', 7200));
     }
 
     /**
@@ -97,9 +97,9 @@ class GetSalesDailyDateStoresTest extends TestCase
         $response = $this->getJson('/api/sales/daily/' . date('Y-m-d', strtotime('-1 day')) . '/stores');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
-        $json->where('details.0.total', 1800*2)
-            ->where('details.1.total', 3600*2)
-            ->where('details.2.total', 5400*2)
-            ->where('details.3.total', 7200*2));
+        $json->where('details.0.amount', 1800*2)
+            ->where('details.1.amount', 3600*2)
+            ->where('details.2.amount', 5400*2)
+            ->where('details.3.amount', 7200*2));
     }
 }

--- a/tests/Feature/GetSalesDailyDateStoresTest.php
+++ b/tests/Feature/GetSalesDailyDateStoresTest.php
@@ -43,7 +43,7 @@ class GetSalesDailyDateStoresTest extends TestCase
     public function test_the_application_returns_a_certain_type(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/stores');
+        $response = $this->getJson('/api/sales/daily/2023-01-01/stores');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
@@ -60,7 +60,7 @@ class GetSalesDailyDateStoresTest extends TestCase
     public function test_the_application_returns_a_correct_store_name(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/stores');
+        $response = $this->getJson('/api/sales/daily/2023-01-01/stores');
         $response->assertStatus(200);
         $stores = ['愛菜館','さんフレッシュ','かわはら夢菜館','わったいな'];
         foreach ($stores as $i => $value) {
@@ -70,36 +70,19 @@ class GetSalesDailyDateStoresTest extends TestCase
     }
 
     /**
-     * Test if you are returns a correct store sales on the day.
+     * Test if you are returns a correct store sales.
      *
      * @return void
      */
-    public function test_the_application_returns_a_correct_store_sales_on_the_day(): void
+    public function test_the_application_returns_a_correct_store_sales(): void
     {
         $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d') . '/stores');
+        $response = $this->getJson('/api/sales/daily/2023-01-01/stores');
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
             $json->where('details.0.amount', 1800)
                 ->where('details.1.amount', 3600)
                 ->where('details.2.amount', 5400)
                 ->where('details.3.amount', 7200));
-    }
-
-    /**
-     * Test if you are returns a correct store sales the previous day.
-     *
-     * @return void
-     */
-    public function test_the_application_returns_a_correct_store_sales_the_previous_day(): void
-    {
-        $this->withoutExceptionHandling();
-        $response = $this->getJson('/api/sales/daily/' . date('Y-m-d', strtotime('-1 day')) . '/stores');
-        $response->assertStatus(200);
-        $response->assertJson(fn (AssertableJson $json) =>
-        $json->where('details.0.amount', 1800*2)
-            ->where('details.1.amount', 3600*2)
-            ->where('details.2.amount', 5400*2)
-            ->where('details.3.amount', 7200*2));
     }
 }


### PR DESCRIPTION
### やったこと
1. GetSalesDailyDateProducts APIのController,Model,Routeの追加
2. GetSalesDailyDateProductsのテスト用シーダーを作成（当日、2日前の売上情報を生成）
3. テストを作成（項目：データ型、商品名、2日前の売上額）
### やらないこと
当日、2日前以外はチェックしない
### 動作確認
仕様書：https://www.notion.so/yumemi/sales-daily-date-products-a2269ddd8db742e6913b08a86505a846
####  指定日（売上個数は1個）
![image](https://user-images.githubusercontent.com/41698195/215043770-4bee57a0-a786-44ac-a8fe-1da91062a1dc.png)
