### PR TITLE
Feature/create get sales date houlry

### DIFF
--- a/app/Http/Controllers/GetSalesDateHourlyController.php
+++ b/app/Http/Controllers/GetSalesDateHourlyController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\HourlySales;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class GetSalesDateHourlyController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param Request $request
+     * @param string $date
+     * @return JsonResponse
+     */
+    public function __invoke(Request $request, string $date): JsonResponse
+    {
+        return response()->json([
+            'details' => HourlySales::fetchHourlySales($date),
+        ], 200, [], JSON_UNESCAPED_UNICODE);
+    }
+}

--- a/app/Http/Controllers/GetSalesDateHourlyController.php
+++ b/app/Http/Controllers/GetSalesDateHourlyController.php
@@ -18,7 +18,7 @@ class GetSalesDateHourlyController extends Controller
     public function __invoke(Request $request, string $date): JsonResponse
     {
         return response()->json([
-            'details' => HourlySales::fetchHourlySales($date),
+            'summary' => HourlySales::fetchHourlySales($date),
         ], 200, [], JSON_UNESCAPED_UNICODE);
     }
 }

--- a/app/Models/HourlySales.php
+++ b/app/Models/HourlySales.php
@@ -35,14 +35,14 @@ class HourlySales extends Model
     {
         return self::query()
             ->select('hour')
-            ->selectRaw('sum(products.price * quantity) as total')
+            ->selectRaw('sum(products.price * quantity) as amount')
             ->where('date', $date)
             ->join('stores', 'stores.id', '=', 'hourly_sales.store_id')
             ->join('products', 'products.id', '=', 'hourly_sales.product_id')
             ->groupBy('hour')
             ->withCasts([
                 'hour' => 'integer',
-                'total' => 'integer',
+                'amount' => 'integer',
             ])->get();
     }
 }

--- a/app/Models/HourlySales.php
+++ b/app/Models/HourlySales.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 class HourlySales extends Model
 {
@@ -23,4 +24,24 @@ class HourlySales extends Model
         'price',
         'quantity',
     ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @param $date
+     * @return Collection
+     */
+    public static function fetchHourlySales($date): Collection
+    {
+        return self::query()
+            ->select('hour')
+            ->selectRaw('sum(products.price * quantity) as total')
+            ->where('date', $date)
+            ->join('stores', 'stores.id', '=', 'hourly_sales.store_id')
+            ->join('products', 'products.id', '=', 'hourly_sales.product_id')
+            ->groupBy('hour')
+            ->withCasts([
+                'total' => 'integer',
+            ])->get();
+    }
 }

--- a/app/Models/HourlySales.php
+++ b/app/Models/HourlySales.php
@@ -41,6 +41,7 @@ class HourlySales extends Model
             ->join('products', 'products.id', '=', 'hourly_sales.product_id')
             ->groupBy('hour')
             ->withCasts([
+                'hour' => 'integer',
                 'total' => 'integer',
             ])->get();
     }

--- a/database/seeders/GetSalesDateHourlyTestSeeder.php
+++ b/database/seeders/GetSalesDateHourlyTestSeeder.php
@@ -19,18 +19,17 @@ class GetSalesDateHourlyTestSeeder extends Seeder
     public function run()
     {
         $user_id = User::orderBy('id', 'asc')->first()->value('id');
-        foreach (Store::orderBy('id', 'asc')->pluck('id') as $store_id ) {
-            foreach (Product::pluck('id') as $product_id) {
-                foreach (range(9, 20) as $idx => $hour ) {
-                    HourlySales::create([
-                        'date' => '2023-01-03',
-                        'hour' => $hour,
-                        'user_id' => $user_id,
-                        'store_id' => $store_id,
-                        'product_id' => $product_id,
-                        'quantity' => $idx,
-                    ]);
-                }
+        $store_id = Store::orderBy('id', 'asc')->first()->value('id');
+        foreach (Product::pluck('id') as $product_id) {
+            foreach (range(9, 20) as $idx => $hour) {
+                HourlySales::create([
+                    'date' => '2023-01-03',
+                    'hour' => $hour,
+                    'user_id' => $user_id,
+                    'store_id' => $store_id,
+                    'product_id' => $product_id,
+                    'quantity' => $idx,
+                ]);
             }
         }
     }

--- a/database/seeders/GetSalesDateHourlyTestSeeder.php
+++ b/database/seeders/GetSalesDateHourlyTestSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\HourlySales;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class GetSalesDateHourlyTestSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $user_id = User::orderBy('id', 'asc')->first()->value('id');
+        foreach (Store::orderBy('id', 'asc')->pluck('id') as $store_id ) {
+            foreach (Product::pluck('id') as $product_id) {
+                foreach (range(9, 20) as $idx => $hour ) {
+                    HourlySales::create([
+                        'date' => '2023-01-03',
+                        'hour' => $hour,
+                        'user_id' => $user_id,
+                        'store_id' => $store_id,
+                        'product_id' => $product_id,
+                        'quantity' => $idx,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\GetSalesDailyController;
 use App\Http\Controllers\GetSalesDailyDateController;
 use App\Http\Controllers\GetSalesDailyDateStoresController;
+use App\Http\Controllers\GetSalesDateHourlyController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -29,3 +30,4 @@ Route::pattern('date', '^([1-9][0-9]{3})-([1-9]{1}|0[1-9]{1}|1[0-2]{1})-([1-9]{1
 Route::get('/sales/daily', GetSalesDailyController::class);
 Route::get('/sales/daily/{date}', GetSalesDailyDateController::class);
 Route::get('/sales/daily/{date}/stores', GetSalesDailyDateStoresController::class);
+Route::get('/sales/{date}/hourly', GetSalesDateHourlyController::class);

--- a/tests/Feature/GetSalesDailyTest.php
+++ b/tests/Feature/GetSalesDailyTest.php
@@ -49,13 +49,13 @@ class GetSalesDailyTest extends TestCase
      */
     public function test_the_application_returns_a_correct_value(): void
     {
-        $amount_all_items_sold_on = 1800;
+        $amount_all_items_sold_one = 1800;
         $this->withoutExceptionHandling();
         $response = $this->getJson('/api/sales/daily/');
         $response->assertStatus(200);
         foreach (range(31, 1) as $i => $days_ago ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_on*$days_ago));
+            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_one*$days_ago));
         }
     }
 }

--- a/tests/Feature/GetSalesDailyTest.php
+++ b/tests/Feature/GetSalesDailyTest.php
@@ -25,7 +25,7 @@ class GetSalesDailyTest extends TestCase
     }
 
     /**
-     * A basic feature test example.
+     * Test if you are returns a certain type.
      *
      * @return void
      */

--- a/tests/Feature/GetSalesDailyTest.php
+++ b/tests/Feature/GetSalesDailyTest.php
@@ -43,17 +43,19 @@ class GetSalesDailyTest extends TestCase
 
     /**
      * Test if you are returns a correct value.
+     * Sales increase by 1800 per day.
      *
      * @return void
      */
     public function test_the_application_returns_a_correct_value(): void
     {
+        $amount_all_items_sold_on = 1800;
         $this->withoutExceptionHandling();
         $response = $this->getJson('/api/sales/daily/');
         $response->assertStatus(200);
-        for ($i = 0; $i < 31; $i++) {
+        foreach (range(31, 1) as $i => $days_ago ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('summary.' . $i . '.amount', 55800 - ($i*1800)));
+            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_on*$days_ago));
         }
     }
 }

--- a/tests/Feature/GetSalesDateHourlyTest.php
+++ b/tests/Feature/GetSalesDateHourlyTest.php
@@ -47,8 +47,8 @@ class GetSalesDateHourlyTest extends TestCase
         $response->assertStatus(200);
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
-            'details.0.hour' => 'integer',
-            'details.0.amount' => 'integer'
+            'summary.0.hour' => 'integer',
+            'summary.0.amount' => 'integer'
         ]));
     }
 
@@ -64,7 +64,7 @@ class GetSalesDateHourlyTest extends TestCase
         $response->assertStatus(200);
         foreach (range(9, 20) as $i => $hour ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('details.' . $i . '.amount', 7200*$i));
+            $json->where('summary.' . $i . '.amount', 7200*$i));
         }
     }
 }

--- a/tests/Feature/GetSalesDateHourlyTest.php
+++ b/tests/Feature/GetSalesDateHourlyTest.php
@@ -60,13 +60,13 @@ class GetSalesDateHourlyTest extends TestCase
      */
     public function test_the_application_returns_a_correct_hourly_sales(): void
     {
-        $amount_all_items_sold_on = 1800;
+        $amount_all_items_sold_one = 1800;
         $this->withoutExceptionHandling();
         $response = $this->getJson('/api/sales/2023-01-03/hourly');
         $response->assertStatus(200);
         foreach (range(9, 20) as $i => $hour ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_on*$i));
+            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_one*$i));
         }
     }
 }

--- a/tests/Feature/GetSalesDateHourlyTest.php
+++ b/tests/Feature/GetSalesDateHourlyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Database\Seeders\GetSalesDateHourlyTestSeeder;
+use Database\Seeders\ProductSeeder;
+use Database\Seeders\StoreSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class GetSalesDateHourlyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(UserSeeder::class);
+        $this->seed(StoreSeeder::class);
+        $this->seed(ProductSeeder::class);
+        $this->seed(GetSalesDateHourlyTestSeeder::class);
+    }
+
+    /**
+     * Return 404 if an invalid value is entered.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_404_if_input_an_invalid_value(): void
+    {
+        $response = $this->get('/api/sales/abc/hours');
+        $response->assertStatus(404);
+    }
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_successful_response_and_a_certain_type(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/2023-01-03/hourly');
+        $response->assertStatus(200);
+        $response->assertJson(fn (AssertableJson $json) =>
+        $json->whereAllType([
+            'details.0.hour' => 'integer',
+            'details.0.total' => 'integer'
+        ]));
+    }
+
+    /**
+     * Test if you are returns a correct hourly sales.
+     *
+     * @return void
+     */
+    public function test_the_application_returns_a_correct_hourly_sales(): void
+    {
+        $this->withoutExceptionHandling();
+        $response = $this->getJson('/api/sales/2023-01-03/hourly');
+        $response->assertStatus(200);
+        foreach (range(9, 20) as $i => $hour ) {
+            $response->assertJson(fn(AssertableJson $json) =>
+            $json->where('details.' . $i . '.total', 7200*$i));
+        }
+    }
+}

--- a/tests/Feature/GetSalesDateHourlyTest.php
+++ b/tests/Feature/GetSalesDateHourlyTest.php
@@ -54,17 +54,19 @@ class GetSalesDateHourlyTest extends TestCase
 
     /**
      * Test if you are returns a correct hourly sales.
+     * Sales increase by 1800 per hour.
      *
      * @return void
      */
     public function test_the_application_returns_a_correct_hourly_sales(): void
     {
+        $amount_all_items_sold_on = 1800;
         $this->withoutExceptionHandling();
         $response = $this->getJson('/api/sales/2023-01-03/hourly');
         $response->assertStatus(200);
         foreach (range(9, 20) as $i => $hour ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('summary.' . $i . '.amount', 7200*$i));
+            $json->where('summary.' . $i . '.amount', $amount_all_items_sold_on*$i));
         }
     }
 }

--- a/tests/Feature/GetSalesDateHourlyTest.php
+++ b/tests/Feature/GetSalesDateHourlyTest.php
@@ -48,7 +48,7 @@ class GetSalesDateHourlyTest extends TestCase
         $response->assertJson(fn (AssertableJson $json) =>
         $json->whereAllType([
             'details.0.hour' => 'integer',
-            'details.0.total' => 'integer'
+            'details.0.amount' => 'integer'
         ]));
     }
 
@@ -64,7 +64,7 @@ class GetSalesDateHourlyTest extends TestCase
         $response->assertStatus(200);
         foreach (range(9, 20) as $i => $hour ) {
             $response->assertJson(fn(AssertableJson $json) =>
-            $json->where('details.' . $i . '.total', 7200*$i));
+            $json->where('details.' . $i . '.amount', 7200*$i));
         }
     }
 }


### PR DESCRIPTION
### やったこと
1. GetSalesDateHoulry APIのController,Model,Routeの追加
2. GetSalesDateHoulryのテスト用シーダーを作成（指定日の売上情報を生成）
3. テストを作成（項目：データ型、時間ごとの売上額）
### やらないこと

### 動作確認
仕様書：https://www.notion.so/yumemi/sales-date-hourly-f7f36a134dbc4da9ab54b107857f11ae
#### 9時の売上：0円（売上個数0個）
#### 10時の売上：7200円（売上個数1個）
![image](https://user-images.githubusercontent.com/41698195/215044190-ed0daabd-8a28-4ab0-a571-89a68442fa34.png)
#### 11時の売上：14400円（売上個数2個）
![image](https://user-images.githubusercontent.com/41698195/215044344-12d963af-d564-489d-bd7e-a51cceb16385.png)
#### 7200円ごと増えていく
